### PR TITLE
Kafka backends

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,4 +12,4 @@ jobs:
       with:
         java-version: 11
     - name: Run tests
-      run: mvn clean verify
+      run: mvn --no-transfer-progress clean verify

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ TBD... Work in progress
 2. Integration tests
     - Class name [Feature]IT.java
     - Test methods [feature to be tested]
+    
+### Utils
+    
+  - start a kafka consumer: ```/opt/kafka/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic service.2.connect.topic --from-beginning --max-messages 100```
+  - set java 11 version: ```export JAVA_HOME=`/usr/libexec/java_home -v 11``` 

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ TBD... Work in progress
 ### Utils
     
   - start a kafka consumer: ```/opt/kafka/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic service.2.connect.topic --from-beginning --max-messages 100```
-  - set java 11 version: ```export JAVA_HOME=`/usr/libexec/java_home -v 11``` 
+  - set java 11 version: ```export JAVA_HOME=`/usr/libexec/java_home -v 11` ``` 

--- a/deployment/docker-compose-kafka.yml
+++ b/deployment/docker-compose-kafka.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  zookeeper:
+    image: zookeeper:3.5.7
+    restart: always
+    ports:
+      - 2181:2181
+  kafka:
+    depends_on:
+      - zookeeper
+    image: wurstmeister/kafka:2.12-2.5.0
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 192.168.100.21
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+#    volumes:
+#      - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-manager:
+    depends_on:
+      - zookeeper
+    image: kafkamanager/kafka-manager:3.0.0.4
+    ports:
+      - 9000:9000
+    environment:
+      ZK_HOSTS: zookeeper:2181

--- a/docs/api/endpoints.http
+++ b/docs/api/endpoints.http
@@ -42,7 +42,8 @@ Content-Type: application/json
         },
         {
           "type": "kafka",
-          "topic": "service.2.connect.topic"
+          "topic": "service.2.connect.topic",
+          "bootstrapServers": "localhost:9092"
         }
       ]
     },
@@ -60,7 +61,8 @@ Content-Type: application/json
         },
         {
           "type": "kafka",
-          "topic": "service.2.diconnect.topic"
+          "topic": "service.2.diconnect.topic",
+          "bootstrapServers": "localhost:9092"
         }
       ]
     },
@@ -141,7 +143,8 @@ Content-Type: application/json
         },
         {
           "type": "kafka",
-          "topic": "service.2.connect.topic"
+          "topic": "service.2.connect.topic",
+          "bootstrapServers": "localhost:9092"
         }
       ]
     },
@@ -159,7 +162,8 @@ Content-Type: application/json
         },
         {
           "type": "kafka",
-          "topic": "service.2.diconnect.topic"
+          "topic": "service.2.diconnect.topic",
+          "bootstrapServers": "localhost:9092"
         }
       ]
     },
@@ -201,7 +205,8 @@ Content-Type: application/json
         },
         {
           "type": "kafka",
-          "topic": "service.2.connect.topic"
+          "topic": "service.2.connect.topic",
+          "bootstrapServers": "localhost:9092"
         }
       ]
     },
@@ -219,7 +224,8 @@ Content-Type: application/json
         },
         {
           "type": "kafka",
-          "topic": "service.2.diconnect.topic"
+          "topic": "service.2.disconnect.topic",
+          "bootstrapServers": "localhost:9092"
         }
       ]
     },
@@ -231,6 +237,11 @@ Content-Type: application/json
           "type": "http",
           "destination": "http://service.1.example.com/default",
           "timeoutInMillis": 300
+        },
+        {
+          "type": "kafka",
+          "topic": "service.2.default.topic",
+          "bootstrapServers": "localhost:9092"
         }
       ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 		<ignite.version>2.8.0</ignite.version>
 		<micrometer-registry.version>1.5.1</micrometer-registry.version>
 		<javatuples.version>1.2</javatuples.version>
+		<reactor-kafka.version>1.2.2.RELEASE</reactor-kafka.version>
 	</properties>
 
 	<dependencyManagement>
@@ -84,6 +85,12 @@
 				<groupId>io.projectreactor.netty</groupId>
 				<artifactId>reactor-netty</artifactId>
 				<version>${reactor-netty.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.projectreactor.kafka</groupId>
+				<artifactId>reactor-kafka</artifactId>
+				<version>${reactor-kafka.version}</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 		<micrometer-registry.version>1.5.1</micrometer-registry.version>
 		<javatuples.version>1.2</javatuples.version>
 		<reactor-kafka.version>1.2.2.RELEASE</reactor-kafka.version>
+		<wiremock.version>2.26.3</wiremock.version>
 	</properties>
 
 	<dependencyManagement>
@@ -217,6 +218,13 @@
 				<artifactId>reactor-test</artifactId>
 				<scope>test</scope>
 				<version>${reactor-core.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.github.tomakehurst</groupId>
+				<artifactId>wiremock-jre8</artifactId>
+				<version>${wiremock.version}</version>
+				<scope>test</scope>
 			</dependency>
 
 			<dependency>

--- a/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/exception/InvalidRequestException.java
+++ b/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/exception/InvalidRequestException.java
@@ -1,0 +1,13 @@
+package com.cosmin.wsgateway.api.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidRequestException extends RuntimeException {
+    private String errorType;
+
+    public InvalidRequestException(String message, String errorType) {
+        super(message);
+        this.errorType = errorType;
+    }
+}

--- a/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/mappers/BackendMapper.java
+++ b/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/mappers/BackendMapper.java
@@ -32,6 +32,7 @@ public class BackendMapper implements RepresentationMapper<BackendRepresentation
 
     @Mapper
     public interface KafkaBackendMapper {
+        @Mapping(target = "settings.bootstrapServers", source = "bootstrapServers")
         KafkaBackend toKafkaBackend(KafkaBackendRepresentation representation);
 
         @InheritInverseConfiguration

--- a/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/mappers/BackendMapper.java
+++ b/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/mappers/BackendMapper.java
@@ -33,6 +33,8 @@ public class BackendMapper implements RepresentationMapper<BackendRepresentation
     @Mapper
     public interface KafkaBackendMapper {
         @Mapping(target = "settings.bootstrapServers", source = "bootstrapServers")
+        @Mapping(target = "settings.retriesNr", source = "retriesNr")
+        @Mapping(target = "settings.acks", source = "acks")
         KafkaBackend toKafkaBackend(KafkaBackendRepresentation representation);
 
         @InheritInverseConfiguration

--- a/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/representation/KafkaBackendRepresentation.java
+++ b/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/representation/KafkaBackendRepresentation.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KafkaBackendRepresentation implements BackendRepresentation {
     private String topic;
+    private String bootstrapServers;
 
     @Override
     @JsonProperty("type")

--- a/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/representation/KafkaBackendRepresentation.java
+++ b/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/representation/KafkaBackendRepresentation.java
@@ -1,12 +1,22 @@
 package com.cosmin.wsgateway.api.representation;
 
+import static java.util.stream.Collectors.toMap;
+
+import com.cosmin.wsgateway.api.exception.InvalidRequestException;
 import com.cosmin.wsgateway.domain.Backend;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Data
 @Builder
@@ -17,9 +27,41 @@ public class KafkaBackendRepresentation implements BackendRepresentation {
     private String topic;
     private String bootstrapServers;
 
+    @Builder.Default
+    private Ack acks = Ack.LEADER;
+
+    @Builder.Default
+    private Integer retriesNr = 1;
+
     @Override
     @JsonProperty("type")
     public String type() {
         return Backend.Type.KAFKA.name().toLowerCase();
+    }
+
+    @RequiredArgsConstructor
+    public enum Ack {
+        NO_ACK("0"),
+        LEADER("1"),
+        ALL("all");
+
+        private final String value;
+
+        private static final Map<String, Ack> valuesByName = Arrays.stream(Ack.values())
+                .collect(toMap(Ack::getValue, Function.identity()));
+
+        @JsonCreator
+        public Ack fromValue(String value) {
+            return Optional.ofNullable(valuesByName.get(value))
+                    .orElseThrow(() -> new InvalidRequestException(
+                            String.format("Kafka ack=%s is not supported", value),
+                            "InvalidKafkaConfiguration"
+                    ));
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
     }
 }

--- a/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/spring/errors/DomainControllerAdvice.java
+++ b/ws-gateway-api/src/main/java/com/cosmin/wsgateway/api/spring/errors/DomainControllerAdvice.java
@@ -3,6 +3,7 @@ package com.cosmin.wsgateway.api.spring.errors;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
+import com.cosmin.wsgateway.api.exception.InvalidRequestException;
 import com.cosmin.wsgateway.api.representation.ErrorRepresentation;
 import com.cosmin.wsgateway.domain.exceptions.BackendNotSupportedException;
 import com.cosmin.wsgateway.domain.exceptions.EndpointNotFoundException;
@@ -38,5 +39,10 @@ public class DomainControllerAdvice {
     @ExceptionHandler(InvalidRouteException.class)
     public ResponseEntity<ErrorRepresentation> handleInvalidRoute(InvalidRouteException exception) {
         return ErrorRepresentation.of(BAD_REQUEST, "InvalidRoute", exception.getMessage()).toResponse();
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ErrorRepresentation> handleInvalidRequest(InvalidRequestException exception) {
+        return ErrorRepresentation.of(BAD_REQUEST, exception.getErrorType(), exception.getMessage()).toResponse();
     }
 }

--- a/ws-gateway-api/src/main/resources/logback-prod.xml
+++ b/ws-gateway-api/src/main/resources/logback-prod.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([%25thread]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
-
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <logger name="com.cosmin.wsgateway.application.gateway" level="INFO"/>
-    <logger name="com.cosmin.wsgateway.api" level="INFO"/>
-    <logger name="org.apache.ignite" level="WARN"/>
-</configuration>

--- a/ws-gateway-api/src/main/resources/logback-spring.xml
+++ b/ws-gateway-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([%25thread]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="com.cosmin.wsgateway.application.gateway" level="DEBUG"/>
+    <logger name="com.cosmin.wsgateway.api" level="DEBUG"/>
+    <logger name="org.apache.ignite" level="WARN"/>
+
+    <springProfile name="prod">
+        <logger name="com.cosmin.wsgateway.application.gateway" level="INFO"/>
+        <logger name="com.cosmin.wsgateway.api" level="INFO"/>
+        <logger name="org.apache.ignite" level="WARN"/>
+    </springProfile>
+
+    <springProfile name="tests">
+        <logger name="org.apache.zookeeper" level="WARN"/>
+        <logger name="org.apache.kafka" level="WARN"/>
+        <logger name="kafka" level="WARN"/>
+        <logger name="org.apache.ignite" level="WARN"/>
+        <logger name="org.eclipse.jetty" level="WARN"/>
+        <logger name="com.github.tomakehurst.wiremock" level="WARN"/>
+        <logger name="com.cosmin.wsgateway.application.gateway" level="DEBUG"/>
+        <logger name="com.cosmin.wsgateway.api" level="DEBUG"/>
+    </springProfile>
+
+</configuration>

--- a/ws-gateway-api/src/main/resources/logback.xml
+++ b/ws-gateway-api/src/main/resources/logback.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([%25thread]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
-
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
-    <logger name="com.cosmin.wsgateway.application.gateway" level="DEBUG"/>
-    <logger name="com.cosmin.wsgateway.api" level="DEBUG"/>
-    <logger name="org.apache.ignite" level="WARN"/>
-</configuration>

--- a/ws-gateway-api/src/main/resources/static/open-api-spec.yml
+++ b/ws-gateway-api/src/main/resources/static/open-api-spec.yml
@@ -1,8 +1,6 @@
 openapi: 3.0.0
 info:
-  description: |
-    WSGateway Api, You find out more on the
-    [Git](https://github.com/cosminseceleanu/ws-gateway) page
+  description: WSGateway Api, You can find out more on the [Git](https://github.com/cosminseceleanu/ws-gateway) page
   version: "1.0.0"
   title: WSGateway Api
   termsOfService: 'https://github.com/cosminseceleanu/ws-gateway'
@@ -370,6 +368,11 @@ components:
                 nullable: false
                 format: uri
                 example: "my.kafka.topic"
+              bootstrapServers:
+                description: List of kafka bootstrap servers - comma separated.Used only by for kafka backends.
+                type: string
+                nullable: false
+                example: "localhost:9092"
             required:
               - type
         expression:

--- a/ws-gateway-api/src/main/resources/static/open-api-spec.yml
+++ b/ws-gateway-api/src/main/resources/static/open-api-spec.yml
@@ -373,6 +373,20 @@ components:
                 type: string
                 nullable: false
                 example: "localhost:9092"
+              acks:
+                description: The number of acknowledgments the producer requires the leader to have received before considering a request complete. Used only by for kafka backends.
+                type: string
+                enum: [0, 1, all]
+                nullable: true
+                default: 1
+                example: "1"
+              retriesNr:
+                description: Number of retries to resend a record whose send fails with a potentially transient error..Used only by for kafka backends.
+                type: integer
+                minimum: 0
+                maximum: 10
+                default: 1
+                nullable: true
             required:
               - type
         expression:

--- a/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/fixtures/BackendFixtures.java
+++ b/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/fixtures/BackendFixtures.java
@@ -1,6 +1,7 @@
 package com.cosmin.wsgateway.api.fixtures;
 
 import com.cosmin.wsgateway.api.representation.HttpBackendRepresentation;
+import com.cosmin.wsgateway.api.representation.KafkaBackendRepresentation;
 import com.cosmin.wsgateway.domain.backends.HttpBackend;
 import com.cosmin.wsgateway.domain.backends.HttpSettings;
 
@@ -25,6 +26,14 @@ public final class BackendFixtures {
         return HttpBackend.builder()
                 .destination(HTTP_DESTINATION)
                 .settings(HttpSettings.builder().timeoutInMillis(120).additionalHeaders(ADDITIONAL_HEADERS).build())
+                .build();
+    }
+
+    public static KafkaBackendRepresentation defaultKafkaRepresentation() {
+        return KafkaBackendRepresentation
+                .builder()
+                .bootstrapServers("servers")
+                .topic("topic")
                 .build();
     }
 }

--- a/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/mappers/BackendMapperTest.java
+++ b/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/mappers/BackendMapperTest.java
@@ -17,6 +17,23 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class BackendMapperTest {
 
+    private final KafkaBackend kafkaModel = KafkaBackend.builder()
+            .settings(KafkaSettings.builder()
+                    .bootstrapServers("servers")
+                    .retriesNr(2)
+                    .acks(KafkaSettings.Ack.ALL)
+                    .build())
+            .topic("topic")
+            .build();
+
+    private final KafkaBackendRepresentation kafkaRepresentation = KafkaBackendRepresentation
+            .builder()
+            .bootstrapServers("servers")
+            .topic("topic")
+            .acks(KafkaBackendRepresentation.Ack.ALL)
+            .retriesNr(2)
+            .build();
+
     private BackendMapper subject = new BackendMapper();
 
     @Test
@@ -49,33 +66,15 @@ class BackendMapperTest {
 
     @Test
     public void testToRepresentation_kafkaBackend_shouldBeMappedToCorrectRepresentation() {
-        KafkaBackend model = KafkaBackend.builder()
-                .settings(KafkaSettings.builder().bootstrapServers("servers").build())
-                .topic("topic")
-                .build();
-        KafkaBackendRepresentation expected = KafkaBackendRepresentation
-                .builder()
-                .bootstrapServers("servers")
-                .topic("topic")
-                .build();
-        BackendRepresentation result = subject.toRepresentation(model);
+        BackendRepresentation result = subject.toRepresentation(kafkaModel);
 
-        assertEquals(expected, result);
+        assertEquals(kafkaRepresentation, result);
     }
 
     @Test
     public void testToModel_kafkaBackendRepresentation_shouldBeMappedToCorrectModel() {
-        KafkaBackend expected = KafkaBackend.builder()
-                .topic("topic")
-                .settings(KafkaSettings.builder().bootstrapServers("servers").build())
-                .build();
-        KafkaBackendRepresentation initial = KafkaBackendRepresentation
-                .builder()
-                .topic("topic")
-                .bootstrapServers("servers")
-                .build();
-        Backend<? extends BackendSettings> result = subject.toModel(initial);
+        Backend<? extends BackendSettings> result = subject.toModel(kafkaRepresentation);
 
-        assertEquals(expected, result);
+        assertEquals(kafkaModel, result);
     }
 }

--- a/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/mappers/BackendMapperTest.java
+++ b/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/mappers/BackendMapperTest.java
@@ -8,6 +8,7 @@ import com.cosmin.wsgateway.domain.BackendSettings;
 import com.cosmin.wsgateway.domain.backends.HttpBackend;
 import com.cosmin.wsgateway.domain.backends.HttpSettings;
 import com.cosmin.wsgateway.domain.backends.KafkaBackend;
+import com.cosmin.wsgateway.domain.backends.KafkaSettings;
 import org.junit.jupiter.api.Test;
 
 import static com.cosmin.wsgateway.api.fixtures.BackendFixtures.ADDITIONAL_HEADERS;
@@ -49,9 +50,14 @@ class BackendMapperTest {
     @Test
     public void testToRepresentation_kafkaBackend_shouldBeMappedToCorrectRepresentation() {
         KafkaBackend model = KafkaBackend.builder()
+                .settings(KafkaSettings.builder().bootstrapServers("servers").build())
                 .topic("topic")
                 .build();
-        KafkaBackendRepresentation expected = KafkaBackendRepresentation.builder().topic("topic").build();
+        KafkaBackendRepresentation expected = KafkaBackendRepresentation
+                .builder()
+                .bootstrapServers("servers")
+                .topic("topic")
+                .build();
         BackendRepresentation result = subject.toRepresentation(model);
 
         assertEquals(expected, result);
@@ -61,8 +67,13 @@ class BackendMapperTest {
     public void testToModel_kafkaBackendRepresentation_shouldBeMappedToCorrectModel() {
         KafkaBackend expected = KafkaBackend.builder()
                 .topic("topic")
+                .settings(KafkaSettings.builder().bootstrapServers("servers").build())
                 .build();
-        KafkaBackendRepresentation initial = KafkaBackendRepresentation.builder().topic("topic").build();
+        KafkaBackendRepresentation initial = KafkaBackendRepresentation
+                .builder()
+                .topic("topic")
+                .bootstrapServers("servers")
+                .build();
         Backend<? extends BackendSettings> result = subject.toModel(initial);
 
         assertEquals(expected, result);

--- a/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/representation/KafkaBackendRepresentationTest.java
+++ b/ws-gateway-api/src/test/java/com/cosmin/wsgateway/api/representation/KafkaBackendRepresentationTest.java
@@ -1,0 +1,33 @@
+package com.cosmin.wsgateway.api.representation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.cosmin.wsgateway.api.fixtures.BackendFixtures;
+import com.cosmin.wsgateway.api.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class KafkaBackendRepresentationTest {
+    private final static String JSON = "{\"topic\":\"topic\",\"bootstrapServers\":\"servers\",\"acks\":\"1\",\"retriesNr\":1,\"type\":\"kafka\"}";
+    private final static String INVALID_JSON = "{\"topic\":\"topic\",\"bootstrapServers\":\"servers\",\"acks\":\"adasdasd\",\"retriesNr\":1,\"type\":\"kafka\"}";
+
+    @Test
+    public void testDeserialize() {
+        var expected = BackendFixtures.defaultKafkaRepresentation();
+        var result = JsonUtils.fromJson(JSON, KafkaBackendRepresentation.class);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testDeserialize_whenAckIsNotSupported_shouldThrowException() {
+        assertThrows(RuntimeException.class, () -> {
+            JsonUtils.fromJson(INVALID_JSON, KafkaBackendRepresentation.class);
+        });
+    }
+
+    @Test
+    public void testSerialize() {
+        var subject = BackendFixtures.defaultKafkaRepresentation();
+        String result = JsonUtils.toJson(subject);
+        assertEquals(JSON, result);
+    }
+}

--- a/ws-gateway-application/src/main/java/com/cosmin/wsgateway/application/gateway/connection/events/BackendErrorEvent.java
+++ b/ws-gateway-application/src/main/java/com/cosmin/wsgateway/application/gateway/connection/events/BackendErrorEvent.java
@@ -2,8 +2,10 @@ package com.cosmin.wsgateway.application.gateway.connection.events;
 
 import com.cosmin.wsgateway.domain.Event;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 
 @RequiredArgsConstructor(staticName = "of")
+@Value
 public class BackendErrorEvent implements InternalEvents {
     private final Event initialEvent;
     private final Throwable error;

--- a/ws-gateway-domain/src/main/java/com/cosmin/wsgateway/domain/backends/KafkaBackend.java
+++ b/ws-gateway-domain/src/main/java/com/cosmin/wsgateway/domain/backends/KafkaBackend.java
@@ -2,6 +2,7 @@ package com.cosmin.wsgateway.domain.backends;
 
 import com.cosmin.wsgateway.domain.Backend;
 import com.cosmin.wsgateway.domain.BackendSettings;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Builder;
@@ -9,10 +10,14 @@ import lombok.Value;
 
 @Value
 @Builder
-public class KafkaBackend implements Backend<BackendSettings.Empty> {
+public class KafkaBackend implements Backend<KafkaSettings> {
     @NotNull
     @Size(min = 5, max = 255)
     private final String topic;
+
+    @NotNull
+    @Valid
+    private final KafkaSettings settings;
 
     @Override
     public String destination() {
@@ -20,8 +25,8 @@ public class KafkaBackend implements Backend<BackendSettings.Empty> {
     }
 
     @Override
-    public BackendSettings.Empty settings() {
-        return BackendSettings.empty();
+    public KafkaSettings settings() {
+        return settings;
     }
 
     @Override

--- a/ws-gateway-domain/src/main/java/com/cosmin/wsgateway/domain/backends/KafkaSettings.java
+++ b/ws-gateway-domain/src/main/java/com/cosmin/wsgateway/domain/backends/KafkaSettings.java
@@ -1,0 +1,13 @@
+package com.cosmin.wsgateway.domain.backends;
+
+import com.cosmin.wsgateway.domain.BackendSettings;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class KafkaSettings implements BackendSettings {
+    @NotNull
+    private final String bootstrapServers;
+}

--- a/ws-gateway-domain/src/main/java/com/cosmin/wsgateway/domain/backends/KafkaSettings.java
+++ b/ws-gateway-domain/src/main/java/com/cosmin/wsgateway/domain/backends/KafkaSettings.java
@@ -1,8 +1,12 @@
 package com.cosmin.wsgateway.domain.backends;
 
 import com.cosmin.wsgateway.domain.BackendSettings;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 @Value
@@ -10,4 +14,21 @@ import lombok.Value;
 public class KafkaSettings implements BackendSettings {
     @NotNull
     private final String bootstrapServers;
+
+    @NotNull
+    private final Ack acks;
+
+    @Min(0)
+    @Max(10)
+    private final int retriesNr;
+
+    @RequiredArgsConstructor
+    @Getter
+    public enum Ack {
+        NO_ACK("0"),
+        LEADER("1"),
+        ALL("all");
+
+        private final String kafkaValue;
+    }
 }

--- a/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/Fixtures.java
+++ b/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/Fixtures.java
@@ -2,6 +2,7 @@ package com.cosmin.wsgateway.domain;
 
 import com.cosmin.wsgateway.domain.backends.HttpBackend;
 import com.cosmin.wsgateway.domain.backends.HttpSettings;
+import com.cosmin.wsgateway.domain.backends.KafkaSettings;
 import java.util.Collections;
 import java.util.Set;
 
@@ -52,5 +53,13 @@ public class Fixtures {
 
     public static HttpSettings defaultHttpSettings() {
         return HttpSettings.builder().additionalHeaders(Collections.emptyMap()).timeoutInMillis(200).build();
+    }
+
+    public static KafkaSettings defaultKafkaSettings() {
+        return KafkaSettings.builder()
+                .bootstrapServers("server")
+                .acks(KafkaSettings.Ack.NO_ACK)
+                .retriesNr(0)
+                .build();
     }
 }

--- a/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/backends/KafkaBackendTest.java
+++ b/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/backends/KafkaBackendTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.cosmin.wsgateway.domain.BaseTest;
+import com.cosmin.wsgateway.domain.Fixtures;
 import javax.validation.ConstraintViolation;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +14,7 @@ class KafkaBackendTest extends BaseTest {
     @Test
     public void testInvalid_whenTopicIsNull() {
         var subject = KafkaBackend.builder()
-                .settings(new KafkaSettings("servers"))
+                .settings(Fixtures.defaultKafkaSettings())
                 .build();
         var constraints = validator.validate(subject);
 
@@ -26,7 +27,7 @@ class KafkaBackendTest extends BaseTest {
     @Test
     public void testInvalid_whenTopicSizeIsSmallerThanAccepted() {
         var subject = KafkaBackend.builder()
-                .settings(new KafkaSettings("servers"))
+                .settings(Fixtures.defaultKafkaSettings())
                 .topic("abcd")
                 .build();
         var constraints = validator.validate(subject);

--- a/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/backends/KafkaBackendTest.java
+++ b/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/backends/KafkaBackendTest.java
@@ -12,7 +12,9 @@ class KafkaBackendTest extends BaseTest {
 
     @Test
     public void testInvalid_whenTopicIsNull() {
-        var subject = KafkaBackend.builder().build();
+        var subject = KafkaBackend.builder()
+                .settings(new KafkaSettings("servers"))
+                .build();
         var constraints = validator.validate(subject);
 
         assertEquals(1, constraints.size());
@@ -23,12 +25,26 @@ class KafkaBackendTest extends BaseTest {
 
     @Test
     public void testInvalid_whenTopicSizeIsSmallerThanAccepted() {
-        var subject = KafkaBackend.builder().topic("abcd").build();
+        var subject = KafkaBackend.builder()
+                .settings(new KafkaSettings("servers"))
+                .topic("abcd")
+                .build();
         var constraints = validator.validate(subject);
 
         assertEquals(1, constraints.size());
         ConstraintViolation<KafkaBackend> violation = constraints.iterator().next();
         assertEquals("topic", violation.getPropertyPath().toString());
         assertThat(violation.getMessage(), containsString("size"));
+    }
+
+    @Test
+    public void testInvalid_whenSettingsAreInvalid() {
+        var subject = KafkaBackend.builder().topic("abcdfghh").build();
+        var constraints = validator.validate(subject);
+
+        assertEquals(1, constraints.size());
+        ConstraintViolation<KafkaBackend> violation = constraints.iterator().next();
+        assertEquals("settings", violation.getPropertyPath().toString());
+        assertThat(violation.getMessage(), containsString("null"));
     }
 }

--- a/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/backends/KafkaSettingsTest.java
+++ b/ws-gateway-domain/src/test/java/com/cosmin/wsgateway/domain/backends/KafkaSettingsTest.java
@@ -1,0 +1,41 @@
+package com.cosmin.wsgateway.domain.backends;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.cosmin.wsgateway.domain.BaseTest;
+import javax.validation.ConstraintViolation;
+import org.junit.jupiter.api.Test;
+
+class KafkaSettingsTest extends BaseTest {
+
+    @Test
+    public void testInvalid_whenAcksIsNull() {
+        var subject = KafkaSettings.builder()
+                .retriesNr(1)
+                .bootstrapServers("assssss")
+                .build();
+        var constraints = validator.validate(subject);
+
+        assertEquals(1, constraints.size());
+        ConstraintViolation<KafkaSettings> violation = constraints.iterator().next();
+        assertEquals("acks", violation.getPropertyPath().toString());
+        assertThat(violation.getMessage(), containsString("null"));
+    }
+
+    @Test
+    public void testInvalid_whenRetriesExceedMaxAllowed() {
+        var subject = KafkaSettings.builder()
+                .retriesNr(111)
+                .acks(KafkaSettings.Ack.LEADER)
+                .bootstrapServers("assssss")
+                .build();
+        var constraints = validator.validate(subject);
+
+        assertEquals(1, constraints.size());
+        ConstraintViolation<KafkaSettings> violation = constraints.iterator().next();
+        assertEquals("retriesNr", violation.getPropertyPath().toString());
+        assertThat(violation.getMessage(), containsString("must be less"));
+    }
+}

--- a/ws-gateway-functional-tests/pom.xml
+++ b/ws-gateway-functional-tests/pom.xml
@@ -20,6 +20,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
@@ -35,7 +41,6 @@
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
             <version>${wiremock.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -49,9 +54,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <version>2.5.1.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
-    <properties>
-        <wiremock.version>2.26.3</wiremock.version>
-    </properties>
 
 </project>

--- a/ws-gateway-functional-tests/src/main/java/com/cosmin/wsgateway/tests/common/EndpointFixtures.java
+++ b/ws-gateway-functional-tests/src/main/java/com/cosmin/wsgateway/tests/common/EndpointFixtures.java
@@ -8,6 +8,7 @@ import com.cosmin.wsgateway.api.representation.AuthenticationRepresentation;
 import com.cosmin.wsgateway.api.representation.EndpointRepresentation;
 import com.cosmin.wsgateway.api.representation.FilterRepresentation;
 import com.cosmin.wsgateway.api.representation.HttpBackendRepresentation;
+import com.cosmin.wsgateway.api.representation.KafkaBackendRepresentation;
 import com.cosmin.wsgateway.api.representation.RouteRepresentation;
 import java.util.Collections;
 import java.util.Set;
@@ -65,6 +66,20 @@ public final class EndpointFixtures {
                 .type(type)
                 .backends(Set.of(
                         HttpBackendRepresentation.builder().destination(backendUrl).build()
+                )).build();
+    }
+
+    public static RouteRepresentation createRouteWithKafkaBackend(
+            RouteRepresentation.Type type, String topic, String server
+    ) {
+        return RouteRepresentation.builder()
+                .name(type.getValue())
+                .type(type)
+                .backends(Set.of(
+                        KafkaBackendRepresentation.builder()
+                                .topic(topic)
+                                .bootstrapServers(server)
+                                .build()
                 )).build();
     }
 }

--- a/ws-gateway-functional-tests/src/main/java/com/cosmin/wsgateway/tests/common/EndpointFixtures.java
+++ b/ws-gateway-functional-tests/src/main/java/com/cosmin/wsgateway/tests/common/EndpointFixtures.java
@@ -49,7 +49,7 @@ public final class EndpointFixtures {
                 .build();
     }
 
-    private static RouteRepresentation createRouteWithHttpBackend(String name, RouteRepresentation.Type type) {
+    public static RouteRepresentation createRouteWithHttpBackend(String name, RouteRepresentation.Type type) {
         return createRouteWithHttpBackend(name, type, "http://localhost:8000");
     }
 

--- a/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/BaseTestIT.java
+++ b/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/BaseTestIT.java
@@ -11,14 +11,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class)
+@ActiveProfiles("tests")
 public abstract class BaseTestIT {
-    private static Logger logger = LoggerFactory.getLogger("FunctionalTests");
+    private static final Logger logger = LoggerFactory.getLogger("FunctionalTests");
 
     @LocalServerPort
     protected int port;

--- a/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/TestsConfiguration.java
+++ b/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/TestsConfiguration.java
@@ -1,0 +1,14 @@
+package com.cosmin.wsgateway.tests;
+
+import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory;
+import org.springframework.boot.web.reactive.server.ReactiveWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestsConfiguration {
+    @Bean
+    public ReactiveWebServerFactory reactiveWebServerFactory() {
+        return new NettyReactiveWebServerFactory();
+    }
+}

--- a/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/gateway/HttpBackendsIT.java
+++ b/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/gateway/HttpBackendsIT.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 import static com.cosmin.wsgateway.tests.common.EndpointFixtures.createRouteWithHttpBackend;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
-public class InboundEventsFlowIT extends BaseTestIT {
+public class HttpBackendsIT extends BaseTestIT {
     public static WireMockServer wiremock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
     private static String backendUrl;
 

--- a/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/gateway/KafkaBackendsIT.java
+++ b/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/gateway/KafkaBackendsIT.java
@@ -1,0 +1,92 @@
+package com.cosmin.wsgateway.tests.gateway;
+
+import static com.cosmin.wsgateway.tests.common.EndpointFixtures.createRouteWithKafkaBackend;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cosmin.wsgateway.api.representation.RouteRepresentation;
+import com.cosmin.wsgateway.tests.BaseTestIT;
+import com.cosmin.wsgateway.tests.common.EndpointFixtures;
+import com.cosmin.wsgateway.tests.common.JsonUtils;
+import com.cosmin.wsgateway.tests.utils.KafkaUtils;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+
+@EmbeddedKafka(partitions = 1)
+public class KafkaBackendsIT extends BaseTestIT {
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Test
+    public void kafkaBackendReceivesConnectAndDisconnectEvent() {
+        Given("An endpoint with kafka backends");
+        var connectTopic = "test.1.connect";
+        var disconnectTopic = "test.1.disconnect";
+        var connectionId = UUID.randomUUID().toString();
+        var expectedPayload = JsonUtils.toJson(Map.of("connectionId", connectionId));
+        var endpoint = EndpointFixtures.getRepresentation("/kafka-backend/test-1", getRoutes(
+                connectTopic, disconnectTopic, "default"
+        ));
+        endpointsClient.createAndAssert(endpoint);
+        embeddedKafkaBroker.addTopics(connectTopic, disconnectTopic);
+
+        When("A WS connection is created with the gateway");
+        var connection = webSocketClient.connect("/kafka-backend/test-1", connectionId);
+        connection.disconnect();
+        await(Duration.ofMillis(3000));
+
+        Then("Kafka backend for connect and disconnect routes has received connection events");
+        var connectionEvents = KafkaUtils.getRecords(connectTopic, embeddedKafkaBroker);
+        var disconnectEvents = KafkaUtils.getRecords(disconnectTopic, embeddedKafkaBroker);
+
+        assertEquals(1, connectionEvents.size());
+        assertEquals(expectedPayload, connectionEvents.get(0));
+
+        assertEquals(1, disconnectEvents.size());
+        assertEquals(expectedPayload, disconnectEvents.get(0));
+    }
+
+    @Test
+    public void kafkaBackendReceivesUserEvents() {
+        Given("An endpoint with kafka backends");
+        var connectionId = UUID.randomUUID().toString();
+        var expectedPayload = JsonUtils.toJson(Map.of("foo", "bar"));
+        var endpoint = EndpointFixtures.getRepresentation("/kafka-backend/test-2", getRoutes(
+                "test.2.connect",
+                "test.2.disconnect",
+                "test.2.default"
+        ));
+        endpointsClient.createAndAssert(endpoint);
+        embeddedKafkaBroker.addTopics("test.2.default");
+
+        When("A WS connection is created and events are sent");
+        var connection = webSocketClient.connect("/kafka-backend/test-2", connectionId);
+        connection.send(expectedPayload);
+        connection.send(expectedPayload);
+        connection.send(expectedPayload);
+        connection.send(expectedPayload);
+        await(Duration.ofMillis(3000));
+
+        Then("Kafka backend receives user sent events");
+        var events = KafkaUtils.getRecords("test.2.default", embeddedKafkaBroker);
+
+        assertEquals(4, events.size());
+        assertEquals(expectedPayload, events.get(0));
+    }
+
+    private Set<RouteRepresentation> getRoutes(String connectTopic, String disconnectTopic, String defaultTopic) {
+        String brokers = embeddedKafkaBroker.getBrokersAsString();
+
+        return Set.of(
+                createRouteWithKafkaBackend(RouteRepresentation.Type.CONNECT, connectTopic, brokers),
+                createRouteWithKafkaBackend(RouteRepresentation.Type.DEFAULT, defaultTopic, brokers),
+                createRouteWithKafkaBackend(RouteRepresentation.Type.DISCONNECT, disconnectTopic, brokers)
+        );
+    }
+}

--- a/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/utils/KafkaUtils.java
+++ b/ws-gateway-functional-tests/src/test/java/com/cosmin/wsgateway/tests/utils/KafkaUtils.java
@@ -1,0 +1,39 @@
+package com.cosmin.wsgateway.tests.utils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.receiver.internals.ConsumerFactory;
+
+public final class KafkaUtils {
+    private KafkaUtils() {}
+
+    public static List<String> getRecords(String topic, EmbeddedKafkaBroker broker) {
+        Map<String, Object> configs = KafkaTestUtils.consumerProps("consumer-" + topic, "false", broker);
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        ReceiverOptions<String, String> receiverOptions = ReceiverOptions.create(configs);
+
+        Consumer<String, String> consumer = ConsumerFactory.INSTANCE.createConsumer(receiverOptions);
+        consumer.subscribe(Collections.singleton(topic));
+        var records = KafkaTestUtils.getRecords(consumer, 5000);
+        consumer.close();
+
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(records.iterator(), Spliterator.ORDERED),
+                false)
+                .map(ConsumerRecord::value)
+                .collect(Collectors.toList());
+    }
+}

--- a/ws-gateway-infrastructure/pom.xml
+++ b/ws-gateway-infrastructure/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.projectreactor.kafka</groupId>
+            <artifactId>reactor-kafka</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty</artifactId>
         </dependency>
@@ -53,7 +58,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-
 
         <dependency>
             <groupId>org.apache.ignite</groupId>

--- a/ws-gateway-infrastructure/pom.xml
+++ b/ws-gateway-infrastructure/pom.xml
@@ -91,5 +91,34 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/ws-gateway-infrastructure/src/main/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/InvalidStatusCodeException.java
+++ b/ws-gateway-infrastructure/src/main/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/InvalidStatusCodeException.java
@@ -1,0 +1,7 @@
+package com.cosmin.wsgateway.infrastructure.gateway.connectors;
+
+public class InvalidStatusCodeException extends RuntimeException {
+    public InvalidStatusCodeException(String message) {
+        super(message);
+    }
+}

--- a/ws-gateway-infrastructure/src/main/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/KafkaConnector.java
+++ b/ws-gateway-infrastructure/src/main/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/KafkaConnector.java
@@ -1,0 +1,62 @@
+package com.cosmin.wsgateway.infrastructure.gateway.connectors;
+
+import com.cosmin.wsgateway.application.gateway.PayloadTransformer;
+import com.cosmin.wsgateway.application.gateway.connection.events.BackendErrorEvent;
+import com.cosmin.wsgateway.application.gateway.connector.BackendConnector;
+import com.cosmin.wsgateway.domain.Backend;
+import com.cosmin.wsgateway.domain.Event;
+import com.cosmin.wsgateway.domain.backends.KafkaSettings;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaConnector implements BackendConnector<KafkaSettings> {
+    private final ConcurrentHashMap<Backend<?>, KafkaSender<String, String>> senders = new ConcurrentHashMap<>();
+
+    private final PayloadTransformer transformer;
+
+    @Override
+    public boolean supports(Backend.Type type) {
+        return Backend.Type.KAFKA.equals(type);
+    }
+
+    @Override
+    public Mono<Event> sendEvent(Event event, Backend<KafkaSettings> backend) {
+        var msg = transformer.fromPayload(event.payload());
+        var record = new ProducerRecord<>(backend.destination(), event.connectionId(), msg);
+
+        return getOrCreateSender(backend)
+                .createOutbound()
+                .send(Mono.just(record))
+                .then()
+                .map(r -> event)
+                .onErrorResume(e -> Mono.just(BackendErrorEvent.of(event, e)));
+    }
+
+    private KafkaSender<String, String> getOrCreateSender(Backend<KafkaSettings> backend) {
+        if (senders.containsKey(backend)) {
+            return senders.get(backend);
+        }
+        Map<String, Object> props = Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, backend.settings().getBootstrapServers(),
+                ProducerConfig.CLIENT_ID_CONFIG, "gateway-kafka-connector",
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class
+        );
+        SenderOptions<String, String> senderOptions = SenderOptions.create(props);
+
+        var sender = KafkaSender.create(senderOptions);
+        senders.put(backend, sender);
+
+        return sender;
+    }
+}

--- a/ws-gateway-infrastructure/src/main/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/KafkaSenderFactory.java
+++ b/ws-gateway-infrastructure/src/main/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/KafkaSenderFactory.java
@@ -1,0 +1,12 @@
+package com.cosmin.wsgateway.infrastructure.gateway.connectors;
+
+import org.springframework.stereotype.Component;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+
+@Component
+public class KafkaSenderFactory {
+    public KafkaSender<String, String> create(SenderOptions<String, String> senderOptions) {
+        return KafkaSender.create(senderOptions);
+    }
+}

--- a/ws-gateway-infrastructure/src/test/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/HttpConnectorTest.java
+++ b/ws-gateway-infrastructure/src/test/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/HttpConnectorTest.java
@@ -61,7 +61,7 @@ class HttpConnectorTest {
 
     @Test
     public void testSendEvent_eventIsSuccessfulSent_shouldReturnInitialEvent() {
-        var event = new Connected("1233455");
+        var event = new Connected("1233456");
         wiremock.stubFor(post(urlPathEqualTo("/test"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
@@ -77,7 +77,7 @@ class HttpConnectorTest {
         wiremock.verify(1, postRequestedFor(urlPathEqualTo("/test"))
                 .withHeader("Content-Type", equalToIgnoreCase("application/json"))
                 .withHeader("X-Debug-Id", equalTo("my-debug-id"))
-                .withRequestBody(equalTo("{\"connectionId\":\"1233455\"}")));
+                .withRequestBody(equalTo("{\"connectionId\":\"1233456\"}")));
     }
 
     @Test

--- a/ws-gateway-infrastructure/src/test/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/HttpConnectorTest.java
+++ b/ws-gateway-infrastructure/src/test/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/HttpConnectorTest.java
@@ -1,0 +1,146 @@
+package com.cosmin.wsgateway.infrastructure.gateway.connectors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import com.cosmin.wsgateway.application.gateway.connection.events.BackendErrorEvent;
+import com.cosmin.wsgateway.domain.backends.HttpBackend;
+import com.cosmin.wsgateway.domain.backends.HttpSettings;
+import com.cosmin.wsgateway.domain.events.Connected;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Fault;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class HttpConnectorTest {
+    private static final WireMockServer wiremock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    private static String wiremockUrl;
+
+    private final HttpBackend backend = HttpBackend.builder()
+            .destination(wiremockUrl + "/test")
+            .settings(HttpSettings.builder()
+                    .additionalHeaders(Map.of(
+                            "X-Debug-Id", "my-debug-id"
+                    ))
+                    .timeoutInMillis(200)
+                    .build())
+            .build();
+
+    @InjectMocks
+    private HttpConnector subject;
+
+    @BeforeAll
+    static void beforeAll() {
+        wiremock.start();
+        wiremockUrl = String.format("http://localhost:%d", wiremock.port());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        wiremock.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        wiremock.resetAll();
+    }
+
+    @Test
+    public void testSendEvent_eventIsSuccessfulSent_shouldReturnInitialEvent() {
+        var event = new Connected("1233455");
+        wiremock.stubFor(post(urlPathEqualTo("/test"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(HttpStatus.NO_CONTENT.value())
+                ));
+
+        var result = subject.sendEvent(event, backend);
+
+        StepVerifier.create(result)
+                .expectNext(event)
+                .verifyComplete();
+
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/test"))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json"))
+                .withHeader("X-Debug-Id", equalTo("my-debug-id"))
+                .withRequestBody(equalTo("{\"connectionId\":\"1233455\"}")));
+    }
+
+    @Test
+    public void testSendEvent_requestToBackendReturn404_shouldReturnAnErrorEvent() {
+        var event = new Connected("1233455");
+        wiremock.stubFor(post(urlPathEqualTo("/test"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(HttpStatus.NOT_FOUND.value())
+                ));
+
+        var result = subject.sendEvent(event, backend);
+
+        StepVerifier.create(result)
+                .expectNextMatches(e -> e instanceof BackendErrorEvent)
+                .verifyComplete();
+    }
+
+    @Test
+    public void testSendEvent_requestToBackendReturn50X_shouldReturnAnErrorEvent() {
+        var event = new Connected("1233455");
+        wiremock.stubFor(post(urlPathEqualTo("/test"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                ));
+
+        var result = subject.sendEvent(event, backend);
+
+        StepVerifier.create(result)
+                .expectNextMatches(e -> e instanceof BackendErrorEvent)
+                .verifyComplete();
+    }
+
+    @Test
+    public void testSendEvent_whenHttpConnectionFails_shouldReturnAnErrorEvent() {
+        var event = new Connected("1233455");
+        wiremock.stubFor(post(urlPathEqualTo("/test"))
+                .willReturn(aResponse()
+                        .withFault(Fault.CONNECTION_RESET_BY_PEER)
+                ));
+
+        var result = subject.sendEvent(event, backend);
+
+        StepVerifier.create(result)
+                .expectNextMatches(e -> e instanceof BackendErrorEvent)
+                .verifyComplete();
+    }
+
+    @Test
+    public void testSendEvent_backendDoesNotRespondInExpectedTimeout_shouldReturnAnErrorEvent() {
+        var event = new Connected("1233455");
+        wiremock.stubFor(post(urlPathEqualTo("/test"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(HttpStatus.NO_CONTENT.value())
+                        .withFixedDelay(10000)
+                ));
+
+        var result = subject.sendEvent(event, backend);
+
+        StepVerifier.create(result)
+                .expectNextMatches(e -> e instanceof BackendErrorEvent)
+                .verifyComplete();
+    }
+}

--- a/ws-gateway-infrastructure/src/test/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/KafkaConnectorTest.java
+++ b/ws-gateway-infrastructure/src/test/java/com/cosmin/wsgateway/infrastructure/gateway/connectors/KafkaConnectorTest.java
@@ -1,0 +1,131 @@
+package com.cosmin.wsgateway.infrastructure.gateway.connectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cosmin.wsgateway.application.gateway.PayloadTransformer;
+import com.cosmin.wsgateway.application.gateway.connection.events.BackendErrorEvent;
+import com.cosmin.wsgateway.domain.backends.KafkaBackend;
+import com.cosmin.wsgateway.domain.backends.KafkaSettings;
+import com.cosmin.wsgateway.domain.events.Connected;
+import lombok.AllArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+import reactor.kafka.sender.SenderResult;
+import reactor.test.StepVerifier;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaConnectorTest {
+
+    private final KafkaBackend kafkaBackend = KafkaBackend.builder()
+            .topic("topic")
+            .settings(KafkaSettings.builder()
+                    .bootstrapServers("servers")
+                    .acks(KafkaSettings.Ack.ALL)
+                    .retriesNr(1)
+                    .build())
+            .build();
+    @Mock
+    private PayloadTransformer payloadTransformer;
+
+    @Mock
+    private KafkaSenderFactory senderFactory;
+
+    @InjectMocks
+    private KafkaConnector subject;
+
+    @Mock
+    private KafkaSender<String, String> kafkaSender;
+
+    @BeforeEach
+    void setUp() {
+        when(payloadTransformer.fromPayload(any())).thenReturn("hello world");
+        when(senderFactory.create(any())).thenReturn(kafkaSender);
+    }
+
+    @Test
+    public void testSendEvent_eventIsSuccessfulSent_shouldReturnInitialEvent() {
+        var event = new Connected("id");
+        when(kafkaSender.send(any())).thenReturn(Flux.just(MockResult.of(null)));
+
+        var result = subject.sendEvent(event, kafkaBackend);
+
+        StepVerifier.create(result)
+                .expectNext(event)
+                .verifyComplete();
+    }
+
+    @Test
+    public void testSendEvent_multipleEventsAreSentToTheSameBackend_thenOnlyOneSenderIsCreated() {
+        var event = new Connected("id");
+        when(kafkaSender.send(any())).thenReturn(Flux.just(MockResult.of(null)));
+
+        subject.sendEvent(event, kafkaBackend);
+        subject.sendEvent(event, kafkaBackend);
+        subject.sendEvent(event, kafkaBackend);
+
+        verify(senderFactory, times(1)).create(any());
+    }
+
+    @Test
+    public void testSendEvent_eventIsNotSent_shouldAnErrorEvent() {
+        var initial = new Connected("id");
+        var error = new RuntimeException("error");
+        when(kafkaSender.send(any())).thenReturn(Flux.just(MockResult.of(error)));
+
+        var result = subject.sendEvent(initial, kafkaBackend);
+
+        StepVerifier.create(result)
+                .expectNext(BackendErrorEvent.of(initial, error))
+                .verifyComplete();
+    }
+
+    @Test
+    public void testSendEvent_givenABackend_shouldCreateSenderWithProperProperties() {
+        var event = new Connected("id");
+        ArgumentCaptor<SenderOptions<String, String>> senderOptionsCaptor = ArgumentCaptor.forClass(SenderOptions.class);
+
+        when(kafkaSender.send(any())).thenReturn(Flux.just(MockResult.of(null)));
+
+        subject.sendEvent(event, kafkaBackend);
+        verify(senderFactory, times(1)).create(senderOptionsCaptor.capture());
+        var options = senderOptionsCaptor.getValue();
+        assertNotNull(options);
+        assertEquals(kafkaBackend.settings().getAcks().getKafkaValue(), options.producerProperty(ProducerConfig.ACKS_CONFIG));
+        assertEquals(kafkaBackend.settings().getRetriesNr(), options.producerProperty(ProducerConfig.RETRIES_CONFIG));
+        assertEquals(kafkaBackend.settings().getBootstrapServers(), options.producerProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+    }
+
+    @AllArgsConstructor(staticName = "of")
+    private static class MockResult implements SenderResult<Object> {
+        private Exception exception;
+
+        @Override
+        public RecordMetadata recordMetadata() {
+            return null;
+        }
+
+        @Override
+        public Exception exception() {
+            return exception;
+        }
+
+        @Override
+        public Object correlationMetadata() {
+            return null;
+        }
+    }
+}

--- a/ws-gateway-infrastructure/src/test/resources/logback.xml
+++ b/ws-gateway-infrastructure/src/test/resources/logback.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <logger name="org.eclipse.jetty" level="WARN"/>
+    <logger name="com.github.tomakehurst.wiremock" level="WARN"/>
+</configuration>


### PR DESCRIPTION
### Changelog:
- Enhance kafka backends with new settings required to send gateway events to a Kafka broker, ex: type of ack, boostrap servers to connect to, number of retries
- Add connector for kafka backends
- Update open api specification
- Configure logs per spring profile
- Small fixes for 
- Add a docker-compose file for a local deployment of a Kafka broker

### Issue: https://github.com/cosminseceleanu/ws-gateway/issues/38